### PR TITLE
Fixed KeyNotFoundException when accessing Logger extension methods

### DIFF
--- a/DepenMock/DepenMock.xml
+++ b/DepenMock/DepenMock.xml
@@ -148,7 +148,7 @@
             <param name="messageFragment">The text fragment to search for in the log messages.</param>
             <exception cref="T:System.Exception">Thrown when no log message contains the specified fragment.</exception>
         </member>
-        <member name="M:DepenMock.ListLoggerAssertionExtensions.ErrorLogs``1(DepenMock.Loggers.ListLogger{``0},Microsoft.Extensions.Logging.LogLevel)">
+        <member name="M:DepenMock.ListLoggerAssertionExtensions.LogMessages``1(DepenMock.Loggers.ListLogger{``0},Microsoft.Extensions.Logging.LogLevel)">
             <summary>
             Helper method to extract log messages of a specific level from the logger.
             </summary>

--- a/DepenMock/Helpers/ListLoggerAssertionExtensions.cs
+++ b/DepenMock/Helpers/ListLoggerAssertionExtensions.cs
@@ -19,7 +19,7 @@ public static class ListLoggerAssertionExtensions
     /// <returns>A list of critical log messages.</returns>
     public static List<string> CriticalLogs<T>(this ListLogger<T> logger)
     {
-        return logger.ErrorLogs(LogLevel.Critical);
+        return logger.LogMessages(LogLevel.Critical);
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ public static class ListLoggerAssertionExtensions
     /// <returns>A list of debug log messages.</returns>
     public static List<string> DebugLogs<T>(this ListLogger<T> logger)
     {
-        return logger.ErrorLogs(LogLevel.Debug);
+        return logger.LogMessages(LogLevel.Debug);
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public static class ListLoggerAssertionExtensions
     /// <returns>A list of error log messages.</returns>
     public static List<string> ErrorLogs<T>(this ListLogger<T> logger)
     {
-        return logger.ErrorLogs(LogLevel.Error);
+        return logger.LogMessages(LogLevel.Error);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public static class ListLoggerAssertionExtensions
     /// <returns>A list of information log messages.</returns>
     public static List<string> InformationLogs<T>(this ListLogger<T> logger)
     {
-        return logger.ErrorLogs(LogLevel.Information);
+        return logger.LogMessages(LogLevel.Information);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public static class ListLoggerAssertionExtensions
     /// <returns>A list of trace log messages.</returns>
     public static List<string> TraceLogs<T>(this ListLogger<T> logger)
     {
-        return logger.ErrorLogs(LogLevel.Trace);
+        return logger.LogMessages(LogLevel.Trace);
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public static class ListLoggerAssertionExtensions
     /// <returns>A list of warning log messages.</returns>
     public static List<string> WarningLogs<T>(this ListLogger<T> logger)
     {
-        return logger.ErrorLogs(LogLevel.Warning);
+        return logger.LogMessages(LogLevel.Warning);
     }
 
     /// <summary>
@@ -98,7 +98,7 @@ public static class ListLoggerAssertionExtensions
     /// <param name="logger">The logger instance to extract messages from.</param>
     /// <param name="logLevel">The log level to filter by.</param>
     /// <returns>A list of log messages for the specified log level.</returns>
-    private static List<string> ErrorLogs<T>(this ListLogger<T> logger, LogLevel logLevel)
+    private static List<string> LogMessages<T>(this ListLogger<T> logger, LogLevel logLevel)
     {
         return logger.Logs[logLevel].ToList();
     }

--- a/DepenMock/Loggers/ListLogger.cs
+++ b/DepenMock/Loggers/ListLogger.cs
@@ -20,7 +20,16 @@ public class ListLogger<TLoggerType> : ILogger<TLoggerType>, ILogger
     /// level is associated with a list of messages.</remarks>
     public ListLogger()
     {
-        Logs = new Dictionary<LogLevel, List<string>>();
+        Logs = new Dictionary<LogLevel, List<string>>
+        {
+            { LogLevel.Trace, new List<string>() },
+            { LogLevel.Debug, new List<string>() },
+            { LogLevel.Information, new List<string>() },
+            { LogLevel.Warning, new List<string>() },
+            { LogLevel.Error, new List<string>() },
+            { LogLevel.Critical, new List<string>() },
+            { LogLevel.None, new List<string>() }
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
When accessing the Logger extension methods, like Logger.ErrorMessages(), and no errors have been logged, a KeyNotFoundException was thrown.

I initialized the logger dictionary with the necessary keys and empty list so KeyNotFoundException will never be thrown.