### PR TITLE
feat: Add FakeItEasy mock abstraction (DepenMock.FakeItEasy)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,5 +65,10 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
 
+      - name: Pack FakeItEasy Package
+        run: dotnet pack DepenMock.FakeItEasy/DepenMock.FakeItEasy.csproj --configuration Release --no-build --output ./nupkgs
+        env:
+          VERSION: ${{ env.VERSION }}
+
       - name: Publish to NuGet
         run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/DepenMock.FakeItEasy/DepenMock.FakeItEasy.csproj
+++ b/DepenMock.FakeItEasy/DepenMock.FakeItEasy.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Title>DepenMock FakeItEasy integration</Title>
+    <PackageId>DepenMock.FakeItEasy</PackageId>
+    <Authors>Xenobiasoft</Authors>
+    <Company>Xenobiasoft</Company>
+    <PackageProjectUrl>https://github.com/xenobiasoft/depenmock</PackageProjectUrl>
+    <Copyright>2026 Xenobiasoft</Copyright>
+    <Description>FakeItEasy integration for DepenMock. Provides FakeItEasyMockFactory and the AsFake() extension for accessing FakeItEasy's A.CallTo() API via the IMock&lt;T&gt; abstraction.</Description>
+    <PackageIcon>x-logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/xenobiasoft/depenmock</RepositoryUrl>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DepenMock\DepenMock.csproj" />
+  </ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\Assets\x-logo.png">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+		<None Include="README.md">
+		  <Pack>True</Pack>
+		  <PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
+
+</Project>

--- a/DepenMock.FakeItEasy/DepenMock.FakeItEasy.xml
+++ b/DepenMock.FakeItEasy/DepenMock.FakeItEasy.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>DepenMock.FakeItEasy</name>
+    </assembly>
+    <members>
+        <member name="T:DepenMock.FakeItEasy.FakeItEasyExtensions">
+            <summary>
+            Extension methods for working with FakeItEasy-backed <see cref="T:DepenMock.Mocks.IMock`1"/> instances.
+            </summary>
+        </member>
+        <member name="M:DepenMock.FakeItEasy.FakeItEasyExtensions.AsFake``1(DepenMock.Mocks.IMock{``0})">
+             <summary>
+             Unwraps the underlying FakeItEasy fake from an <see cref="T:DepenMock.Mocks.IMock`1"/>, giving
+             access to FakeItEasy's <c>A.CallTo()</c> API for setup and assertion.
+             </summary>
+             <typeparam name="T">The mocked type.</typeparam>
+             <param name="mock">The <see cref="T:DepenMock.Mocks.IMock`1"/> returned by <c>Container.ResolveMock&lt;T&gt;()</c>.</param>
+             <returns>The underlying FakeItEasy fake instance.</returns>
+             <example>
+             <code>
+             // Stub
+             var fakeRepo = Container.ResolveMock&lt;IDeskRepository&gt;().AsFake();
+             A.CallTo(() => fakeRepo.GetAvailableDesks(A&lt;DateTime&gt;._))
+                 .Returns(Container.CreateMany&lt;Desk&gt;());
+            
+             // Spy
+             var fakeBookingRepo = Container.ResolveMock&lt;IDeskBookingRepository&gt;().AsFake();
+             A.CallTo(() => fakeBookingRepo.Save(A&lt;DeskBooking&gt;._)).MustHaveHappenedOnceExactly();
+             </code>
+             </example>
+        </member>
+        <member name="T:DepenMock.FakeItEasy.FakeItEasyMock`1">
+            <summary>
+            An <see cref="T:DepenMock.Mocks.IMock`1"/> implementation backed by a FakeItEasy fake. Access the
+            underlying <see cref="P:DepenMock.FakeItEasy.FakeItEasyMock`1.Fake"/> property (or call <see cref="M:DepenMock.FakeItEasy.FakeItEasyExtensions.AsFake``1(DepenMock.Mocks.IMock{``0})"/>)
+            to use FakeItEasy's <c>A.CallTo()</c> API.
+            </summary>
+            <typeparam name="T">The type being faked. Must be a reference type.</typeparam>
+        </member>
+        <member name="M:DepenMock.FakeItEasy.FakeItEasyMock`1.#ctor(`0)">
+            <summary>
+            Initializes a new instance of <see cref="T:DepenMock.FakeItEasy.FakeItEasyMock`1"/> wrapping the given fake.
+            </summary>
+            <param name="fake">The underlying FakeItEasy fake instance.</param>
+        </member>
+        <member name="P:DepenMock.FakeItEasy.FakeItEasyMock`1.Object">
+            <inheritdoc />
+        </member>
+        <member name="P:DepenMock.FakeItEasy.FakeItEasyMock`1.Fake">
+            <summary>
+            Gets the underlying FakeItEasy fake instance, providing access to
+            <c>A.CallTo()</c> for setup and assertion.
+            </summary>
+        </member>
+        <member name="T:DepenMock.FakeItEasy.FakeItEasyMockFactory">
+            <summary>
+            An <see cref="T:DepenMock.Mocks.IMockFactory"/> implementation that uses FakeItEasy and AutoFixture.AutoFakeItEasy to
+            automatically create and register fakes for unregistered dependencies.
+            </summary>
+        </member>
+        <member name="M:DepenMock.FakeItEasy.FakeItEasyMockFactory.GetCustomization">
+            <inheritdoc />
+            <remarks>
+            Returns an <see cref="T:AutoFixture.AutoFakeItEasy.AutoFakeItEasyCustomization"/> with <c>ConfigureMembers = true</c>, which
+            instructs AutoFixture to automatically configure all members of auto-created fakes.
+            </remarks>
+        </member>
+        <member name="M:DepenMock.FakeItEasy.FakeItEasyMockFactory.GetMock``1(AutoFixture.IFixture)">
+            <inheritdoc />
+            <remarks>
+            Freezes <typeparamref name="T"/> in the fixture so the same fake instance is reused whenever
+            <typeparamref name="T"/> is resolved, then wraps it in a <see cref="T:DepenMock.FakeItEasy.FakeItEasyMock`1"/>.
+            </remarks>
+        </member>
+    </members>
+</doc>

--- a/DepenMock.FakeItEasy/FakeItEasyExtensions.cs
+++ b/DepenMock.FakeItEasy/FakeItEasyExtensions.cs
@@ -1,0 +1,31 @@
+using DepenMock.Mocks;
+
+namespace DepenMock.FakeItEasy;
+
+/// <summary>
+/// Extension methods for working with FakeItEasy-backed <see cref="IMock{T}"/> instances.
+/// </summary>
+public static class FakeItEasyExtensions
+{
+    /// <summary>
+    /// Unwraps the underlying FakeItEasy fake from an <see cref="IMock{T}"/>, giving
+    /// access to FakeItEasy's <c>A.CallTo()</c> API for setup and assertion.
+    /// </summary>
+    /// <typeparam name="T">The mocked type.</typeparam>
+    /// <param name="mock">The <see cref="IMock{T}"/> returned by <c>Container.ResolveMock&lt;T&gt;()</c>.</param>
+    /// <returns>The underlying FakeItEasy fake instance.</returns>
+    /// <example>
+    /// <code>
+    /// // Stub
+    /// var fakeRepo = Container.ResolveMock&lt;IDeskRepository&gt;().AsFake();
+    /// A.CallTo(() => fakeRepo.GetAvailableDesks(A&lt;DateTime&gt;._))
+    ///     .Returns(Container.CreateMany&lt;Desk&gt;());
+    ///
+    /// // Spy
+    /// var fakeBookingRepo = Container.ResolveMock&lt;IDeskBookingRepository&gt;().AsFake();
+    /// A.CallTo(() => fakeBookingRepo.Save(A&lt;DeskBooking&gt;._)).MustHaveHappenedOnceExactly();
+    /// </code>
+    /// </example>
+    public static T AsFake<T>(this IMock<T> mock) where T : class =>
+        ((FakeItEasyMock<T>)mock).Fake;
+}

--- a/DepenMock.FakeItEasy/FakeItEasyMock.cs
+++ b/DepenMock.FakeItEasy/FakeItEasyMock.cs
@@ -1,0 +1,30 @@
+using DepenMock.Mocks;
+
+namespace DepenMock.FakeItEasy;
+
+/// <summary>
+/// An <see cref="IMock{T}"/> implementation backed by a FakeItEasy fake. Access the
+/// underlying <see cref="Fake"/> property (or call <see cref="FakeItEasyExtensions.AsFake{T}"/>)
+/// to use FakeItEasy's <c>A.CallTo()</c> API.
+/// </summary>
+/// <typeparam name="T">The type being faked. Must be a reference type.</typeparam>
+public class FakeItEasyMock<T> : IMock<T> where T : class
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="FakeItEasyMock{T}"/> wrapping the given fake.
+    /// </summary>
+    /// <param name="fake">The underlying FakeItEasy fake instance.</param>
+    public FakeItEasyMock(T fake)
+    {
+        Fake = fake;
+    }
+
+    /// <inheritdoc />
+    public T Object => Fake;
+
+    /// <summary>
+    /// Gets the underlying FakeItEasy fake instance, providing access to
+    /// <c>A.CallTo()</c> for setup and assertion.
+    /// </summary>
+    public T Fake { get; }
+}

--- a/DepenMock.FakeItEasy/FakeItEasyMockFactory.cs
+++ b/DepenMock.FakeItEasy/FakeItEasyMockFactory.cs
@@ -1,0 +1,26 @@
+using AutoFixture;
+using AutoFixture.AutoFakeItEasy;
+using DepenMock.Mocks;
+
+namespace DepenMock.FakeItEasy;
+
+/// <summary>
+/// An <see cref="IMockFactory"/> implementation that uses FakeItEasy and AutoFixture.AutoFakeItEasy to
+/// automatically create and register fakes for unregistered dependencies.
+/// </summary>
+public class FakeItEasyMockFactory : IMockFactory
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns an <see cref="AutoFakeItEasyCustomization"/> with <c>ConfigureMembers = true</c>, which
+    /// instructs AutoFixture to automatically configure all members of auto-created fakes.
+    /// </remarks>
+    public ICustomization GetCustomization() => new AutoFakeItEasyCustomization { ConfigureMembers = true };
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Freezes <typeparamref name="T"/> in the fixture so the same fake instance is reused whenever
+    /// <typeparamref name="T"/> is resolved, then wraps it in a <see cref="FakeItEasyMock{T}"/>.
+    /// </remarks>
+    public IMock<T> GetMock<T>(IFixture fixture) where T : class => new FakeItEasyMock<T>(fixture.Freeze<T>());
+}

--- a/DepenMock.FakeItEasy/README.md
+++ b/DepenMock.FakeItEasy/README.md
@@ -1,0 +1,192 @@
+# DepenMock.FakeItEasy
+
+FakeItEasy integration for [DepenMock](https://github.com/xenobiasoft/depenmock) — a C# testing library that automates mock creation for your System Under Test (SUT) dependencies.
+
+Install this package alongside one of the DepenMock test-framework packages (`DepenMock.XUnit`, `DepenMock.NUnit`, or `DepenMock.MSTest`) to use FakeItEasy as your mocking framework.
+
+## Installation
+
+```
+dotnet add package DepenMock.FakeItEasy
+dotnet add package DepenMock.XUnit   # or DepenMock.NUnit / DepenMock.MSTest
+```
+
+## Setting Up the Test Container
+
+The base classes require an `IMockFactory` to be passed through the constructor. The recommended approach is to define a project-level base class once that wires up `FakeItEasyMockFactory`, so individual test classes need no constructor boilerplate.
+
+**Recommended: project-level base class**
+
+Define these once in your test project and inherit from them everywhere:
+
+```c#
+public abstract class TestByAbstraction<TType, TInterface>
+    : BaseTestByAbstraction<TType, TInterface>(new FakeItEasyMockFactory())
+    where TType : class, TInterface;
+
+public abstract class TestByType<TType>
+    : BaseTestByType<TType>(new FakeItEasyMockFactory())
+    where TType : class;
+```
+
+Then each test class simply inherits with no constructor required:
+
+```c#
+public class DeskBookingRequestProcessorTests
+    : TestByAbstraction<DeskBookingRequestProcessor, IDeskBookingRequestProcessor>
+{
+    // Your test methods here
+}
+```
+
+**Alternative: pass the factory directly**
+
+If you prefer not to define a shared base class, pass the factory explicitly per test class:
+
+```c#
+public class DeskBookingRequestProcessorTests
+    : BaseTestByAbstraction<DeskBookingRequestProcessor, IDeskBookingRequestProcessor>
+{
+    public DeskBookingRequestProcessorTests()
+        : base(new FakeItEasyMockFactory()) { }
+}
+
+public class AccountControllerTests : BaseTestByType<AccountController>
+{
+    public AccountControllerTests()
+        : base(new FakeItEasyMockFactory()) { }
+}
+```
+
+## Creating the System Under Test (SUT)
+
+Call `ResolveSut()` as the final step of your arrange phase, after any mock setup.
+
+```c#
+var sut = ResolveSut();
+```
+
+## Creating Mock Data
+
+**Create\<T>()**
+
+The `Create<T>` method generates a single instance of the specified type.
+
+```c#
+// Creates a random string in the format of a guid i.e "fe06998d-aec1-4808-8968-d8f37024a294"
+var name = Container.Create<string>();
+
+// Creates a random integer greater than 0
+var id = Container.Create<int>();
+
+// Creates a boolean value set to true
+var isEnabled = Container.Create<bool>();
+
+// Creates a random date set in the future
+var startDate = Container.Create<DateTime>();
+
+// Creates an instance of the class MyObj
+var myObjInstance = Container.Create<MyObj>();
+
+// Creates a list of strings. NOTE: Use CreateMany for generating lists.
+var randomStrings = Container.Create<List<string>>();
+```
+
+**CreateMany\<T>(int? numberOfInstances)**
+
+The `CreateMany<T>` method generates a list of instances of the specified type. By default it creates three items, but you can customise the count with the `numberOfInstances` parameter.
+
+```c#
+// Creates a list of strings
+var randomStrings = Container.CreateMany<string>();
+
+// Creates a list of random integers
+var randomNumbers = Container.CreateMany<int>();
+
+// Creates a list of boolean values. All values will be set to true.
+var allTrueValues = Container.CreateMany<bool>();
+
+// Creates a list of random dates. This example creates a list of 5 random dates.
+var randomDates = Container.CreateMany<DateTime>(5);
+
+// Creates a list of addresses set to random values
+var addressList = Container.CreateMany<Address>();
+```
+
+**Build\<T>()**
+
+The `Build<T>` method provides a builder pattern for creating objects with specific values rather than using all auto-generated data.
+
+```c#
+var deskBookingResult = Container
+    .Build<DeskBookingResult>()
+    .Without(x => x.DeskBookingId) // DeskBookingId will be set to null
+    .With(x => x.Code, DeskBookingResultCode.Success)
+    .With(x => x.FirstName, request.FirstName)
+    .With(x => x.LastName, request.LastName)
+    .With(x => x.Email, request.Email)
+    .With(x => x.Date, request.Date)
+    .Create();
+```
+
+## Creating Mock Dependencies
+
+DepenMock automatically creates FakeItEasy fakes for all unregistered dependencies. Call `ResolveMock<T>()` to get a reference to a fake, then use `AsFake()` to access FakeItEasy's `A.CallTo()` API.
+
+**Creating a stub**
+
+```c#
+var fakeRepo = Container.ResolveMock<IDeskRepository>().AsFake();
+A.CallTo(() => fakeRepo.GetAvailableDesks(A<DateTime>._))
+    .Returns(Container.CreateMany<Desk>());
+```
+
+**Creating a spy**
+
+```c#
+var fakeBookingRepo = Container.ResolveMock<IDeskBookingRepository>().AsFake();
+
+// ... act ...
+
+A.CallTo(() => fakeBookingRepo.Save(A<DeskBooking>._)).MustHaveHappenedOnceExactly();
+```
+
+## Testing Logging
+
+DepenMock provides a `ListLogger` and automatically injects it as a dependency for your tests.
+
+```c#
+Logger.ErrorLogs().AssertContains($"Correlation Id: {correlationId}");
+
+// Accessing logs by level directly
+Logger.Logs[LogLevel.Error]
+Logger.Logs[LogLevel.Critical]
+Logger.Logs[LogLevel.Warning]
+Logger.Logs[LogLevel.Information]
+```
+
+## Extending Fixture Customization
+
+Override `AddContainerCustomizations` to register custom `ISpecimenBuilder` instances or otherwise control how objects are created.
+
+```c#
+public class MyTests : BaseTestByType<MyType>
+{
+    public MyTests() : base(new FakeItEasyMockFactory()) { }
+
+    protected override void AddContainerCustomizations(Container container)
+    {
+        container.AddCustomizations(new MyCustomSpecimenBuilder());
+    }
+}
+```
+
+You can add as many custom builders as you need:
+
+```c#
+container.AddCustomizations(new MyBuilder1(), new MyBuilder2());
+```
+
+## Sample Project
+
+Explore the sample project, DeskBooker.Core, which includes example unit tests for NUnit, XUnit, and MSTest to help you get started with DepenMock.

--- a/DepenMock.sln
+++ b/DepenMock.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.5.11709.299 stable
+VisualStudioVersion = 18.5.11709.299
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9D2563E9-00E4-47FB-A811-C5514C0F0895}"
 	ProjectSection(SolutionItems) = preProject
@@ -61,6 +61,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DepenMock.NSubstitute", "DepenMock.NSubstitute\DepenMock.NSubstitute.csproj", "{576F0FAA-4BFE-4A4E-8DCF-F105BA262110}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.NSubstitute", "Tests.NSubstitute\Tests.NSubstitute.csproj", "{C5FC59DC-258F-4652-A386-04F5C0A13752}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DepenMock.FakeItEasy", "DepenMock.FakeItEasy\DepenMock.FakeItEasy.csproj", "{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.FakeItEasy", "Tests.FakeItEasy\Tests.FakeItEasy.csproj", "{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -228,6 +232,30 @@ Global
 		{C5FC59DC-258F-4652-A386-04F5C0A13752}.Release|x64.Build.0 = Release|Any CPU
 		{C5FC59DC-258F-4652-A386-04F5C0A13752}.Release|x86.ActiveCfg = Release|Any CPU
 		{C5FC59DC-258F-4652-A386-04F5C0A13752}.Release|x86.Build.0 = Release|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Release|x64.Build.0 = Release|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D}.Release|x86.Build.0 = Release|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Debug|x64.Build.0 = Debug|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Debug|x86.Build.0 = Debug|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Release|x64.ActiveCfg = Release|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Release|x64.Build.0 = Release|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Release|x86.ActiveCfg = Release|Any CPU
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -246,6 +274,8 @@ Global
 		{C5686283-7BB8-41B0-A50B-1692335B715B} = {84824EEA-9CD0-4DAC-B094-7F30A4C052A8}
 		{576F0FAA-4BFE-4A4E-8DCF-F105BA262110} = {958CD65F-9771-466D-9406-30242D27716C}
 		{C5FC59DC-258F-4652-A386-04F5C0A13752} = {84824EEA-9CD0-4DAC-B094-7F30A4C052A8}
+		{D4A5B6C7-E8F9-4A0B-8C2D-3E4F5A6B7C8D} = {958CD65F-9771-466D-9406-30242D27716C}
+		{E5B6C7D8-F9A0-4B1C-8D3E-4F5A6B7C8D9E} = {84824EEA-9CD0-4DAC-B094-7F30A4C052A8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {284E7EF4-397A-4A30-9631-D539CC8078FB}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,27 @@
 
 ---
 
+## v3.1.0
+
+### What's Changed
+
+**FakeItEasy support added (`DepenMock.FakeItEasy`)**
+
+A new `DepenMock.FakeItEasy` package is now available, giving teams the option to use FakeItEasy as their mocking framework alongside the existing Moq and NSubstitute adapters. It includes `FakeItEasyMockFactory`, `FakeItEasyMock<T>`, and an `AsFake()` extension method for unwrapping fakes from the `IMock<T>` abstraction.
+
+```csharp
+// Stub using FakeItEasy
+var fakeRepo = Container.ResolveMock<IDeskRepository>().AsFake();
+A.CallTo(() => fakeRepo.GetAvailableDesks(A<DateTime>._))
+    .Returns(Container.CreateMany<Desk>());
+
+// Spy using FakeItEasy
+var fakeBookingRepo = Container.ResolveMock<IDeskBookingRepository>().AsFake();
+A.CallTo(() => fakeBookingRepo.Save(A<DeskBooking>._)).MustHaveHappenedOnceExactly();
+```
+
+---
+
 ## v3.0.0
 
 ### What's Changed

--- a/Tests.FakeItEasy/DeskBookingRequestProcessorTests.cs
+++ b/Tests.FakeItEasy/DeskBookingRequestProcessorTests.cs
@@ -1,0 +1,173 @@
+using AutoFixture;
+using DepenMock;
+using DepenMock.Attributes;
+using DepenMock.FakeItEasy;
+using DeskBooker.Core.Domain;
+using DeskBooker.Core.Interfaces;
+using DeskBooker.Core.Processor;
+using FakeItEasy;
+
+namespace Tests.FakeItEasy;
+
+
+[LogOutput(LogOutputTiming.Always)]
+public class DeskBookingRequestProcessorTests : FakeItEasyBaseTestByAbstraction<DeskBookingRequestProcessor, IDeskBookingRequestProcessor>
+{
+    [Fact]
+	public void BookDesk_WhenDeskAvailable_ReturnsBookedDeskResult()
+	{
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var request = Container.Create<DeskBookingRequest>();
+		var expectedResult = Container
+			.Build<DeskBookingResult>()
+			.With(x => x.DeskBookingId, 0)
+			.With(x => x.Code, DeskBookingResultCode.Success)
+			.With(x => x.FirstName, request.FirstName)
+			.With(x => x.LastName, request.LastName)
+			.With(x => x.Email, request.Email)
+			.With(x => x.Date, request.Date)
+			.Create();
+		var sut = ResolveSut();
+
+		// Act
+		var actualResult = sut.BookDesk(request, correlationId);
+
+		// Assert
+		Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Fact]
+	public void BookDesk_WhenDeskIsNull_ThrowsException()
+	{
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var sut = ResolveSut();
+
+		// Act
+		void BookDesk() => sut.BookDesk(null, correlationId);
+
+		// Assert
+		Assert.Throws<ArgumentNullException>(BookDesk);
+	}
+
+    [Fact]
+    public void BookDesk_WhenDeskIsNull_LogsError()
+    {
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var sut = ResolveSut();
+
+        try
+        {
+            // Act
+            sut.BookDesk(null, correlationId);
+        }
+        catch
+        {
+            // Assert
+            Logger.ErrorLogs().AssertContains($"Correlation Id: {correlationId}");
+        }
+    }
+
+    [Fact]
+	public void BookDesk_WhenDeskAvailable_BooksDesk()
+	{
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var fakeBookingRepo = Container.ResolveMock<IDeskBookingRepository>().AsFake();
+        var fakeDeskRepo = Container.ResolveMock<IDeskRepository>().AsFake();
+        A.CallTo(() => fakeDeskRepo.GetAvailableDesks(A<DateTime>._))
+            .Returns(Container.CreateMany<Desk>());
+
+		var sut = ResolveSut();
+
+		// Act
+		sut.BookDesk(Container.Create<DeskBookingRequest>(), correlationId);
+
+        // Assert
+        A.CallTo(() => fakeBookingRepo.Save(A<DeskBooking>._)).MustHaveHappenedOnceExactly();
+    }
+
+	[Fact]
+	public void BookDesk_WhenNoDeskAvailable_DoesNotBookDesk()
+	{
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var fakeDeskRepo = Container.ResolveMock<IDeskRepository>().AsFake();
+        A.CallTo(() => fakeDeskRepo.GetAvailableDesks(A<DateTime>._))
+            .Returns(new List<Desk>());
+        var fakeBookingRepo = Container.ResolveMock<IDeskBookingRepository>().AsFake();
+		var sut = ResolveSut();
+
+		// Act
+		sut.BookDesk(Container.Create<DeskBookingRequest>(), correlationId);
+
+		// Assert
+		A.CallTo(() => fakeBookingRepo.Save(A<DeskBooking>._)).MustNotHaveHappened();
+	}
+
+	[Fact]
+	public void BookDesk_WhenNoAvailableDesks_ReturnStatusNoDeskAvailable()
+	{
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var fakeDeskRepo = Container.ResolveMock<IDeskRepository>().AsFake();
+        A.CallTo(() => fakeDeskRepo.GetAvailableDesks(A<DateTime>._))
+            .Returns(new List<Desk>());
+
+		var sut = ResolveSut();
+
+		// Act
+		var result = sut.BookDesk(Container.Create<DeskBookingRequest>(), correlationId);
+
+		// Assert
+		Assert.Equal(DeskBookingResultCode.NoDeskAvailable, result.Code);
+	}
+
+	[Fact]
+	public void BookDesk_WhenDeskAvailable_ReturnStatusAvailableDesks()
+	{
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var sut = ResolveSut();
+
+		// Act
+		var result = sut.BookDesk(Container.Create<DeskBookingRequest>(), correlationId);
+
+		// Assert
+		Assert.Equal(DeskBookingResultCode.Success, result.Code);
+	}
+
+	[Fact]
+	public void BookDesk_WhenNoDeskAvailable_ReturnsEmptyDeskBookingId()
+	{
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var fakeDeskRepo = Container.ResolveMock<IDeskRepository>().AsFake();
+        A.CallTo(() => fakeDeskRepo.GetAvailableDesks(A<DateTime>._))
+            .Returns(new List<Desk>());
+
+		var sut = ResolveSut();
+
+		// Act
+		var result = sut.BookDesk(Container.Create<DeskBookingRequest>(), correlationId);
+
+		// Assert
+		Assert.Null(result.DeskBookingId);
+	}
+
+	[Fact]
+	public void BookDesk_WhenDeskAvailable_ReturnsDeskBookingId()
+	{
+        // Assemble
+        var correlationId = Container.Create<string>();
+        var sut = ResolveSut();
+
+		// Act
+		var result = sut.BookDesk(Container.Create<DeskBookingRequest>(), correlationId);
+
+		// Assert
+		Assert.Equal(0, result.DeskBookingId);
+	}
+}

--- a/Tests.FakeItEasy/FakeItEasyBaseTestByAbstraction.cs
+++ b/Tests.FakeItEasy/FakeItEasyBaseTestByAbstraction.cs
@@ -1,0 +1,8 @@
+using DepenMock.FakeItEasy;
+using DepenMock.XUnit.V3;
+
+namespace Tests.FakeItEasy;
+
+public class FakeItEasyBaseTestByAbstraction<TType, TInterfaceType>()
+    : BaseTestByAbstraction<TType, TInterfaceType>(new FakeItEasyMockFactory())
+    where TType : class, TInterfaceType;

--- a/Tests.FakeItEasy/Tests.FakeItEasy.csproj
+++ b/Tests.FakeItEasy/Tests.FakeItEasy.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+	  <PackageReference Include="FakeItEasy" Version="8.3.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+	  <PackageReference Include="xunit.v3" Version="3.2.2" />
+	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DepenMock.FakeItEasy\DepenMock.FakeItEasy.csproj" />
+    <ProjectReference Include="..\DepenMock.XUnit.V3\DepenMock.XUnit.V3.csproj" />
+    <ProjectReference Include="..\DeskBooker.Core\DeskBooker.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #42

## Summary

- Adds `DepenMock.FakeItEasy` package with `FakeItEasyMockFactory`, `FakeItEasyMock<T>`, and `AsFake()` extension method — mirrors the NSubstitute adapter pattern
- Adds `Tests.FakeItEasy` validation project using xUnit v3, porting the full `DeskBookingRequestProcessorTests` suite with FakeItEasy's `A.CallTo()` API
- Updates `DepenMock.sln` to include both new projects
- Adds `Pack FakeItEasy Package` step to `.github/workflows/publish.yml`
- Documents the new package in `RELEASES.md` under v3.1.0

## Test plan

- [x] `dotnet build --configuration Release` succeeds (0 warnings, 0 errors)
- [x] `dotnet test --configuration Release` passes all tests including `Tests.FakeItEasy` (9/9 passed)
- [x] `AsFake<T>()` correctly unwraps to FakeItEasy's fake for use with `A.CallTo()`
- [x] Pack step wired into publish workflow on `v*` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)