### PR TITLE
feat: Add .NET 10 multi-targeting support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore dependencies
         run: dotnet restore

--- a/DepenMock.FakeItEasy/DepenMock.FakeItEasy.csproj
+++ b/DepenMock.FakeItEasy/DepenMock.FakeItEasy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Title>DepenMock FakeItEasy integration</Title>
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
-    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="FakeItEasy" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DepenMock.MSTest/DepenMock.MSTest.csproj
+++ b/DepenMock.MSTest/DepenMock.MSTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<AssemblyName>$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -30,8 +30,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MSTest.TestFramework" Version="3.11.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.11.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DepenMock.Moq/DepenMock.Moq.csproj
+++ b/DepenMock.Moq/DepenMock.Moq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/DepenMock.NSubstitute/DepenMock.NSubstitute.csproj
+++ b/DepenMock.NSubstitute/DepenMock.NSubstitute.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Title>DepenMock NSubstitute integration</Title>

--- a/DepenMock.NUnit/DepenMock.NUnit.csproj
+++ b/DepenMock.NUnit/DepenMock.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<AssemblyName>$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnit" Version="4.4.0" />
+		<PackageReference Include="NUnit" Version="4.6.0" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -41,8 +41,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Update="README.md">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		<None Include="README.md">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>

--- a/DepenMock.XUnit.V3/DepenMock.XUnit.V3.csproj
+++ b/DepenMock.XUnit.V3/DepenMock.XUnit.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<AssemblyName>$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -42,8 +42,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Update="README.md">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		<None Include="README.md">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>

--- a/DepenMock.XUnit/DepenMock.XUnit.csproj
+++ b/DepenMock.XUnit/DepenMock.XUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<AssemblyName>$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -46,8 +46,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Update="README.md">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		<None Include="README.md">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>

--- a/DepenMock/DepenMock.csproj
+++ b/DepenMock/DepenMock.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>false</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
@@ -40,8 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="README.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    <None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/DeskBooker.Core/DeskBooker.Core.csproj
+++ b/DeskBooker.Core/DeskBooker.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/Tests.FakeItEasy/Tests.FakeItEasy.csproj
+++ b/Tests.FakeItEasy/Tests.FakeItEasy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="FakeItEasy" Version="8.3.0" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+	  <PackageReference Include="FakeItEasy" Version="9.0.1" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	  <PackageReference Include="xunit.v3" Version="3.2.2" />
 	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 		  <PrivateAssets>all</PrivateAssets>

--- a/Tests.MSTest/ContainerTests.cs
+++ b/Tests.MSTest/ContainerTests.cs
@@ -177,7 +177,7 @@ namespace Tests.MSTest
         public void AddCustomizations_WithNullBuilders_ShouldThrowArgumentNullException()
         {
             // Act & Assert
-            Assert.ThrowsException<ArgumentNullException>(() => _container.AddCustomizations(null));
+            Assert.Throws<ArgumentNullException>(() => _container.AddCustomizations(null));
         }
 
         [TestMethod]
@@ -187,7 +187,7 @@ namespace Tests.MSTest
             var validBuilder = new Mock<ISpecimenBuilder>();
 
             // Act & Assert
-            Assert.ThrowsException<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
                 _container.AddCustomizations(validBuilder.Object, null));
         }
 

--- a/Tests.MSTest/DeskBookingRequestProcessorTests.cs
+++ b/Tests.MSTest/DeskBookingRequestProcessorTests.cs
@@ -40,15 +40,14 @@ public class DeskBookingRequestProcessorTests()
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void BookDesk_WhenDeskIsNull_ThrowsException()
     {
         // Assemble
         var correlationId = Container.Create<string>();
         var sut = ResolveSut();
 
-        // Act
-        sut.BookDesk(null, correlationId);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => sut.BookDesk(null, correlationId));
     }
 
     [TestMethod]

--- a/Tests.MSTest/ListLoggerAssertionExtensionsTests.cs
+++ b/Tests.MSTest/ListLoggerAssertionExtensionsTests.cs
@@ -142,7 +142,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Fourth";
 
         // Act & Assert
-        var exception = Assert.ThrowsException<Exception>(() => messages.ContainsMessage(searchFragment));
+        var exception = Assert.Throws<Exception>(() => messages.ContainsMessage(searchFragment));
         Assert.IsTrue(exception.Message.Contains(searchFragment));
     }
 
@@ -154,7 +154,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Any message";
 
         // Act & Assert
-        Assert.ThrowsException<Exception>(() => messages.ContainsMessage(searchFragment));
+        Assert.Throws<Exception>(() => messages.ContainsMessage(searchFragment));
     }
 
     [TestMethod]
@@ -198,7 +198,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Fourth";
 
         // Act & Assert
-        var exception = Assert.ThrowsException<Exception>(() => messages.AssertContains(searchFragment));
+        var exception = Assert.Throws<Exception>(() => messages.AssertContains(searchFragment));
         Assert.IsTrue(exception.Message.Contains(searchFragment));
     }
 
@@ -210,7 +210,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Any message";
 
         // Act & Assert
-        Assert.ThrowsException<Exception>(() => messages.AssertContains(searchFragment));
+        Assert.Throws<Exception>(() => messages.AssertContains(searchFragment));
     }
 
     [TestMethod]

--- a/Tests.MSTest/Tests.MSTest.csproj
+++ b/Tests.MSTest/Tests.MSTest.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.11.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests.NSubstitute/Tests.NSubstitute.csproj
+++ b/Tests.NSubstitute/Tests.NSubstitute.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	  <PackageReference Include="NSubstitute" Version="5.3.0" />
 	  <PackageReference Include="xunit.v3" Version="3.2.2" />
 	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Tests.NUnit/ContainerTests.cs
+++ b/Tests.NUnit/ContainerTests.cs
@@ -172,14 +172,14 @@ public class ContainerTests
         var builder = new Mock<ISpecimenBuilder>();
 
         // Act & Assert - Should not throw
-        Assert.DoesNotThrow(() => _container.AddCustomizations(builder.Object));
+        Assert.DoesNotThrow((TestDelegate)(() => _container.AddCustomizations(builder.Object)));
     }
 
     [Test]
     public void AddCustomizations_WithNullBuilders_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => _container.AddCustomizations(null));
+        Assert.Throws<ArgumentNullException>((TestDelegate)(() => _container.AddCustomizations(null)));
     }
 
     [Test]
@@ -189,8 +189,8 @@ public class ContainerTests
         var validBuilder = new Mock<ISpecimenBuilder>();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => 
-            _container.AddCustomizations(validBuilder.Object, null));
+        Assert.Throws<ArgumentNullException>((TestDelegate)(() =>
+            _container.AddCustomizations(validBuilder.Object, null)));
     }
 
     public class TestModel

--- a/Tests.NUnit/ControllerCustomizationTests.cs
+++ b/Tests.NUnit/ControllerCustomizationTests.cs
@@ -17,7 +17,7 @@ public class ControllerCustomizationTests
         var customization = new ControllerCustomization();
 
         // Act & Assert - Should not throw
-        Assert.DoesNotThrow(() => customization.Customize(fixture));
+        Assert.DoesNotThrow((TestDelegate)(() => customization.Customize(fixture)));
         Assert.That(customization, Is.Not.Null);
     }
 

--- a/Tests.NUnit/DeskBookingRequestProcessorTests.cs
+++ b/Tests.NUnit/DeskBookingRequestProcessorTests.cs
@@ -53,7 +53,7 @@ public class DeskBookingRequestProcessorTests : BaseTestByAbstraction<DeskBookin
 		void BookDesk() => sut.BookDesk(null, correlationId);
 
 		// Assert
-		Assert.Throws<ArgumentNullException>(BookDesk);
+		Assert.Throws<ArgumentNullException>((TestDelegate)BookDesk);
     }
 
     [Test]
@@ -163,7 +163,7 @@ public class DeskBookingRequestProcessorTests : BaseTestByAbstraction<DeskBookin
 		var result = sut.BookDesk(Container.Create<DeskBookingRequest>(), correlationId);
 
 		// Assert
-		Assert.That(null, Is.EqualTo(result.DeskBookingId));
+		Assert.That((object)null, Is.EqualTo(result.DeskBookingId));
 	}
 
 	[Test]

--- a/Tests.NUnit/ListLoggerAssertionExtensionsTests.cs
+++ b/Tests.NUnit/ListLoggerAssertionExtensionsTests.cs
@@ -123,7 +123,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Second";
 
         // Act & Assert - Should not throw
-        Assert.DoesNotThrow(() => messages.ContainsMessage(searchFragment));
+        Assert.DoesNotThrow((TestDelegate)(() => messages.ContainsMessage(searchFragment)));
     }
 
     [Test]
@@ -134,7 +134,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "second";
 
         // Act & Assert - Should not throw
-        Assert.DoesNotThrow(() => messages.ContainsMessage(searchFragment));
+        Assert.DoesNotThrow((TestDelegate)(() => messages.ContainsMessage(searchFragment)));
     }
 
     [Test]
@@ -145,7 +145,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Fourth";
 
         // Act & Assert
-        var exception = Assert.Throws<Exception>(() => messages.ContainsMessage(searchFragment));
+        var exception = Assert.Throws<Exception>((TestDelegate)(() => messages.ContainsMessage(searchFragment)));
         Assert.That(exception.Message, Does.Contain(searchFragment));
     }
 
@@ -157,7 +157,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Any message";
 
         // Act & Assert
-        Assert.Throws<Exception>(() => messages.ContainsMessage(searchFragment));
+        Assert.Throws<Exception>((TestDelegate)(() => messages.ContainsMessage(searchFragment)));
     }
 
     [Test]
@@ -168,7 +168,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "complete";
 
         // Act & Assert - Should not throw
-        Assert.DoesNotThrow(() => messages.ContainsMessage(searchFragment));
+        Assert.DoesNotThrow((TestDelegate)(() => messages.ContainsMessage(searchFragment)));
     }
 
     [Test]
@@ -179,7 +179,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Second";
 
         // Act & Assert - Should not throw
-        Assert.DoesNotThrow(() => messages.AssertContains(searchFragment));
+        Assert.DoesNotThrow((TestDelegate)(() => messages.AssertContains(searchFragment)));
     }
 
     [Test]
@@ -190,7 +190,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "second";
 
         // Act & Assert - Should not throw
-        Assert.DoesNotThrow(() => messages.AssertContains(searchFragment));
+        Assert.DoesNotThrow((TestDelegate)(() => messages.AssertContains(searchFragment)));
     }
 
     [Test]
@@ -201,7 +201,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Fourth";
 
         // Act & Assert
-        var exception = Assert.Throws<Exception>(() => messages.AssertContains(searchFragment));
+        var exception = Assert.Throws<Exception>((TestDelegate)(() => messages.AssertContains(searchFragment)));
         Assert.That(exception.Message, Does.Contain(searchFragment));
     }
 
@@ -213,7 +213,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "Any message";
 
         // Act & Assert
-        Assert.Throws<Exception>(() => messages.AssertContains(searchFragment));
+        Assert.Throws<Exception>((TestDelegate)(() => messages.AssertContains(searchFragment)));
     }
 
     [Test]
@@ -224,7 +224,7 @@ public class ListLoggerAssertionExtensionsTests
         var searchFragment = "complete";
 
         // Act & Assert - Should not throw
-        Assert.DoesNotThrow(() => messages.AssertContains(searchFragment));
+        Assert.DoesNotThrow((TestDelegate)(() => messages.AssertContains(searchFragment)));
     }
 
     private class TestClass { }

--- a/Tests.NUnit/ListLoggerClearTest.cs
+++ b/Tests.NUnit/ListLoggerClearTest.cs
@@ -39,7 +39,7 @@ public class ListLoggerClearTest
     public void Clear_WithEmptyLogs_ShouldNotThrow()
     {
         // Act & Assert
-        Assert.DoesNotThrow(() => _logger.Clear());
+        Assert.DoesNotThrow((TestDelegate)(() => _logger.Clear()));
     }
 
     private class TestClass { }

--- a/Tests.NUnit/Tests.NUnit.csproj
+++ b/Tests.NUnit/Tests.NUnit.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests.XUnit.V3/Tests.XUnit.V3.csproj
+++ b/Tests.XUnit.V3/Tests.XUnit.V3.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests.XUnit/Tests.XUnit.csproj
+++ b/Tests.XUnit/Tests.XUnit.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

Adds **.NET 10** support across the repo by multi-targeting all projects (`net8.0;net10.0`) and bumping the test/CI toolchain. The library still ships for net8.0, so existing consumers are unaffected.

## Changes

- **Multi-targeting** — `<TargetFramework>net8.0</TargetFramework>` → `<TargetFrameworks>net8.0;net10.0</TargetFrameworks>` across all 7 packages, the sample (`DeskBooker.Core`), and all test projects.
- **Package bumps** — NUnit 4.4→4.6, NUnit3TestAdapter 5.1→6.2, MSTest 3.11→4.2.3, Microsoft.NET.Test.Sdk 18.0→18.5.1, FakeItEasy 8.3→9.0.1, Microsoft.Extensions.Logging 9→10.
- **CI** — `setup-dotnet` `8.0.x` → `10.0.x` in `build-and-test.yml` and `publish.yml`.
- **Breaking-API fixes:**
  - NUnit 4.6 added `Action` overloads alongside `TestDelegate`, causing CS0121 ambiguities — resolved with explicit `(TestDelegate)`/`(object)null` casts.
  - MSTest 4.x removed `[ExpectedException]` and `Assert.ThrowsException<T>` — replaced with `Assert.Throws<T>`.
- **README packaging hardening** — `DepenMock`, `DepenMock.XUnit`, `DepenMock.XUnit.V3`, `DepenMock.NUnit` switched from `<None Update="README.md">` + `CopyToOutputDirectory=Always` to `<None Include="README.md">`, removing a non-deterministic `NU5039` pack race that appeared on clean multi-targeting builds.

## Testing

- `dotnet test -c Release` — **288 tests pass on each TFM** (net8.0 + net10.0), 0 failures, 0 skipped.
- Two consecutive `dotnet clean` + full Release builds: **0 `NU5039` errors** (was 4 on the original clean build before the readme fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)