### PR TITLE
feat: Add SetupMock<T>() convenience method (#35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ DepenMock is a .NET 8 test helper library that combines AutoFixture with a plugg
 
 ### Core (`DepenMock/`)
 
-- **`Container`** — the central class. Wraps AutoFixture's `IFixture` and manages mock instances. `Resolve<T>()` builds SUT instances with all dependencies auto-mocked; `GetMock<T>()` retrieves (or creates and caches) an `IMock<T>` for a specific dependency.
+- **`Container`** — the central class. Wraps AutoFixture's `IFixture` and manages mock instances. `Resolve<T>()` builds SUT instances with all dependencies auto-mocked; `ResolveMock<T>()` retrieves (or creates and caches) an `IMock<T>` for a specific dependency.
 - **`IMock<T>` / `IMockFactory`** — abstractions that decouple the core from any specific mocking library. Each mocking-framework adapter implements `IMockFactory` to produce `IMock<T>` wrappers.
 - **`BaseTest` / `BaseTestByAbstraction<,>` / `BaseTestByType<>`** — base test classes (provided per test-framework adapter) with a `Container` property and a virtual `AddContainerCustomizations()` hook.
 - **`ListLogger<T>`** — in-memory `ILogger<T>` implementation for asserting log output in tests.
@@ -39,8 +39,11 @@ DepenMock is a .NET 8 test helper library that combines AutoFixture with a plugg
 |---|---|
 | `DepenMock.Moq` | `MoqMockFactory`, `MoqMock<T>`, `.AsMoq()` extension |
 | `DepenMock.NSubstitute` | `NSubstituteMockFactory`, `NSubstituteMock<T>`, `.AsNSubstitute()` extension |
+| `DepenMock.FakeItEasy` | `FakeItEasyMockFactory`, `FakeItEasyMock<T>`, `.AsFake()` extension |
 
-AutoFixture glue (`AutoMoqCustomization` / `AutoNSubstituteCustomization`) is wired inside each factory.
+AutoFixture glue (`AutoMoqCustomization` / `AutoNSubstituteCustomization` / `AutoFakeItEasyCustomization`) is wired inside each factory.
+
+Each adapter also defines a `SetupMock<T>()` extension method on `Container` that resolves the mock, applies an inline configuration action written against that framework's native mock type, and returns the `Container` for chaining. It shares the same mock cache as `ResolveMock<T>()`.
 
 ### Test-framework adapters
 

--- a/DepenMock.FakeItEasy/DepenMock.FakeItEasy.xml
+++ b/DepenMock.FakeItEasy/DepenMock.FakeItEasy.xml
@@ -30,6 +30,29 @@
              </code>
              </example>
         </member>
+        <member name="M:DepenMock.FakeItEasy.FakeItEasyExtensions.SetupMock``1(DepenMock.Container,System.Action{``0})">
+            <summary>
+            Resolves the mock for <typeparamref name="T"/> and applies <paramref name="setup"/> to the
+            underlying FakeItEasy fake inline, without needing an intermediate variable. The fake is the
+            same cached instance returned by <c>Container.ResolveMock&lt;T&gt;()</c>, so any
+            configuration applied here is visible to the system under test.
+            </summary>
+            <typeparam name="T">The faked type.</typeparam>
+            <param name="container">The container that owns the fake.</param>
+            <param name="setup">The configuration to apply to the underlying fake.</param>
+            <returns>The same <see cref="T:DepenMock.Container"/>, so that calls can be chained.</returns>
+            <example>
+            <code>
+            Container
+                .SetupMock&lt;IDeskRepository&gt;(f => A
+                    .CallTo(() => f.GetAvailableDesks(A&lt;DateTime&gt;._))
+                    .Returns(Container.CreateMany&lt;Desk&gt;()))
+                .SetupMock&lt;IDeskBookingRepository&gt;(f => A
+                    .CallTo(() => f.Save(A&lt;DeskBooking&gt;._))
+                    .DoesNothing());
+            </code>
+            </example>
+        </member>
         <member name="T:DepenMock.FakeItEasy.FakeItEasyMock`1">
             <summary>
             An <see cref="T:DepenMock.Mocks.IMock`1"/> implementation backed by a FakeItEasy fake. Access the

--- a/DepenMock.FakeItEasy/FakeItEasyExtensions.cs
+++ b/DepenMock.FakeItEasy/FakeItEasyExtensions.cs
@@ -28,4 +28,34 @@ public static class FakeItEasyExtensions
     /// </example>
     public static T AsFake<T>(this IMock<T> mock) where T : class =>
         ((FakeItEasyMock<T>)mock).Fake;
+
+    /// <summary>
+    /// Resolves the mock for <typeparamref name="T"/> and applies <paramref name="setup"/> to the
+    /// underlying FakeItEasy fake inline, without needing an intermediate variable. The fake is the
+    /// same cached instance returned by <c>Container.ResolveMock&lt;T&gt;()</c>, so any
+    /// configuration applied here is visible to the system under test.
+    /// </summary>
+    /// <typeparam name="T">The faked type.</typeparam>
+    /// <param name="container">The container that owns the fake.</param>
+    /// <param name="setup">The configuration to apply to the underlying fake.</param>
+    /// <returns>The same <see cref="Container"/>, so that calls can be chained.</returns>
+    /// <example>
+    /// <code>
+    /// Container
+    ///     .SetupMock&lt;IDeskRepository&gt;(f => A
+    ///         .CallTo(() => f.GetAvailableDesks(A&lt;DateTime&gt;._))
+    ///         .Returns(Container.CreateMany&lt;Desk&gt;()))
+    ///     .SetupMock&lt;IDeskBookingRepository&gt;(f => A
+    ///         .CallTo(() => f.Save(A&lt;DeskBooking&gt;._))
+    ///         .DoesNothing());
+    /// </code>
+    /// </example>
+    public static Container SetupMock<T>(this Container container, Action<T> setup) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(setup);
+
+        setup(container.ResolveMock<T>().AsFake());
+
+        return container;
+    }
 }

--- a/DepenMock.FakeItEasy/README.md
+++ b/DepenMock.FakeItEasy/README.md
@@ -141,6 +141,22 @@ A.CallTo(() => fakeRepo.GetAvailableDesks(A<DateTime>._))
     .Returns(Container.CreateMany<Desk>());
 ```
 
+**Creating a stub with `SetupMock`**
+
+For stubs that don't need to be asserted on later, `SetupMock<T>()` applies the configuration inline and returns the `Container`, so several dependencies can be stubbed in a single chain without intermediate variables.
+
+```c#
+Container
+    .SetupMock<IDeskRepository>(f => A
+        .CallTo(() => f.GetAvailableDesks(A<DateTime>._))
+        .Returns(Container.CreateMany<Desk>()))
+    .SetupMock<IDeskBookingRepository>(f => A
+        .CallTo(() => f.Save(A<DeskBooking>._))
+        .DoesNothing());
+```
+
+`SetupMock<T>()` configures the same cached fake that `ResolveMock<T>()` returns, so the two can be mixed freely.
+
 **Creating a spy**
 
 ```c#

--- a/DepenMock.Moq/DepenMock.Moq.xml
+++ b/DepenMock.Moq/DepenMock.Moq.xml
@@ -30,6 +30,28 @@
              </code>
              </example>
         </member>
+        <member name="M:DepenMock.Moq.MoqExtensions.SetupMock``1(DepenMock.Container,System.Action{Moq.Mock{``0}})">
+            <summary>
+            Resolves the mock for <typeparamref name="T"/> and applies <paramref name="setup"/> to the
+            underlying Moq <see cref="T:Moq.Mock`1"/> inline, without needing an intermediate variable. The
+            mock is the same cached instance returned by <c>Container.ResolveMock&lt;T&gt;()</c>, so any
+            configuration applied here is visible to the system under test.
+            </summary>
+            <typeparam name="T">The mocked type.</typeparam>
+            <param name="container">The container that owns the mock.</param>
+            <param name="setup">The configuration to apply to the underlying <see cref="T:Moq.Mock`1"/>.</param>
+            <returns>The same <see cref="T:DepenMock.Container"/>, so that calls can be chained.</returns>
+            <example>
+            <code>
+            Container
+                .SetupMock&lt;IDeskRepository&gt;(m => m
+                    .Setup(x => x.GetAvailableDesks(It.IsAny&lt;DateTime&gt;()))
+                    .Returns(Container.CreateMany&lt;Desk&gt;()))
+                .SetupMock&lt;IDeskBookingRepository&gt;(m => m
+                    .Setup(x => x.Save(It.IsAny&lt;DeskBooking&gt;())));
+            </code>
+            </example>
+        </member>
         <member name="T:DepenMock.Moq.MoqMock`1">
             <summary>
             An <see cref="T:DepenMock.Mocks.IMock`1"/> implementation backed by a Moq <see cref="T:Moq.Mock`1"/>. Access the

--- a/DepenMock.Moq/MoqExtensions.cs
+++ b/DepenMock.Moq/MoqExtensions.cs
@@ -29,4 +29,33 @@ public static class MoqExtensions
     /// </example>
     public static Mock<T> AsMoq<T>(this Mocks.IMock<T> mock) where T : class =>
         ((MoqMock<T>)mock).Mock;
+
+    /// <summary>
+    /// Resolves the mock for <typeparamref name="T"/> and applies <paramref name="setup"/> to the
+    /// underlying Moq <see cref="Mock{T}"/> inline, without needing an intermediate variable. The
+    /// mock is the same cached instance returned by <c>Container.ResolveMock&lt;T&gt;()</c>, so any
+    /// configuration applied here is visible to the system under test.
+    /// </summary>
+    /// <typeparam name="T">The mocked type.</typeparam>
+    /// <param name="container">The container that owns the mock.</param>
+    /// <param name="setup">The configuration to apply to the underlying <see cref="Mock{T}"/>.</param>
+    /// <returns>The same <see cref="Container"/>, so that calls can be chained.</returns>
+    /// <example>
+    /// <code>
+    /// Container
+    ///     .SetupMock&lt;IDeskRepository&gt;(m => m
+    ///         .Setup(x => x.GetAvailableDesks(It.IsAny&lt;DateTime&gt;()))
+    ///         .Returns(Container.CreateMany&lt;Desk&gt;()))
+    ///     .SetupMock&lt;IDeskBookingRepository&gt;(m => m
+    ///         .Setup(x => x.Save(It.IsAny&lt;DeskBooking&gt;())));
+    /// </code>
+    /// </example>
+    public static Container SetupMock<T>(this Container container, Action<Mock<T>> setup) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(setup);
+
+        setup(container.ResolveMock<T>().AsMoq());
+
+        return container;
+    }
 }

--- a/DepenMock.Moq/README.md
+++ b/DepenMock.Moq/README.md
@@ -143,6 +143,21 @@ Container
     .Returns(Container.CreateMany<Desk>());
 ```
 
+**Creating a stub with `SetupMock`**
+
+For stubs that don't need to be verified later, `SetupMock<T>()` applies the configuration inline and returns the `Container`, so several dependencies can be stubbed in a single chain without intermediate variables.
+
+```c#
+Container
+    .SetupMock<IDeskRepository>(m => m
+        .Setup(x => x.GetAvailableDesks(It.IsAny<DateTime>()))
+        .Returns(Container.CreateMany<Desk>()))
+    .SetupMock<IDeskBookingRepository>(m => m
+        .Setup(x => x.Save(It.IsAny<DeskBooking>())));
+```
+
+`SetupMock<T>()` configures the same cached mock that `ResolveMock<T>()` returns, so the two can be mixed freely.
+
 **Creating a spy**
 
 ```c#

--- a/DepenMock.NSubstitute/DepenMock.NSubstitute.xml
+++ b/DepenMock.NSubstitute/DepenMock.NSubstitute.xml
@@ -30,6 +30,29 @@
              </code>
              </example>
         </member>
+        <member name="M:DepenMock.NSubstitute.NSubstituteExtensions.SetupMock``1(DepenMock.Container,System.Action{``0})">
+            <summary>
+            Resolves the mock for <typeparamref name="T"/> and applies <paramref name="setup"/> to the
+            underlying NSubstitute substitute inline, without needing an intermediate variable. The
+            substitute is the same cached instance returned by <c>Container.ResolveMock&lt;T&gt;()</c>,
+            so any configuration applied here is visible to the system under test.
+            </summary>
+            <typeparam name="T">The mocked type.</typeparam>
+            <param name="container">The container that owns the mock.</param>
+            <param name="setup">The configuration to apply to the underlying substitute.</param>
+            <returns>The same <see cref="T:DepenMock.Container"/>, so that calls can be chained.</returns>
+            <example>
+            <code>
+            Container
+                .SetupMock&lt;IDeskRepository&gt;(s => s
+                    .GetAvailableDesks(Arg.Any&lt;DateTime&gt;())
+                    .Returns(Container.CreateMany&lt;Desk&gt;()))
+                .SetupMock&lt;IDeskBookingRepository&gt;(s => s
+                    .When(x => x.Save(Arg.Any&lt;DeskBooking&gt;()))
+                    .Do(_ => throw new InvalidOperationException()));
+            </code>
+            </example>
+        </member>
         <member name="T:DepenMock.NSubstitute.NSubstituteMock`1">
             <summary>
             An <see cref="T:DepenMock.Mocks.IMock`1"/> implementation backed by an NSubstitute substitute. Access the

--- a/DepenMock.NSubstitute/NSubstituteExtensions.cs
+++ b/DepenMock.NSubstitute/NSubstituteExtensions.cs
@@ -28,4 +28,34 @@ public static class NSubstituteExtensions
     /// </example>
     public static T AsNSubstitute<T>(this IMock<T> mock) where T : class =>
         ((NSubstituteMock<T>)mock).Substitute;
+
+    /// <summary>
+    /// Resolves the mock for <typeparamref name="T"/> and applies <paramref name="setup"/> to the
+    /// underlying NSubstitute substitute inline, without needing an intermediate variable. The
+    /// substitute is the same cached instance returned by <c>Container.ResolveMock&lt;T&gt;()</c>,
+    /// so any configuration applied here is visible to the system under test.
+    /// </summary>
+    /// <typeparam name="T">The mocked type.</typeparam>
+    /// <param name="container">The container that owns the mock.</param>
+    /// <param name="setup">The configuration to apply to the underlying substitute.</param>
+    /// <returns>The same <see cref="Container"/>, so that calls can be chained.</returns>
+    /// <example>
+    /// <code>
+    /// Container
+    ///     .SetupMock&lt;IDeskRepository&gt;(s => s
+    ///         .GetAvailableDesks(Arg.Any&lt;DateTime&gt;())
+    ///         .Returns(Container.CreateMany&lt;Desk&gt;()))
+    ///     .SetupMock&lt;IDeskBookingRepository&gt;(s => s
+    ///         .When(x => x.Save(Arg.Any&lt;DeskBooking&gt;()))
+    ///         .Do(_ => throw new InvalidOperationException()));
+    /// </code>
+    /// </example>
+    public static Container SetupMock<T>(this Container container, Action<T> setup) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(setup);
+
+        setup(container.ResolveMock<T>().AsNSubstitute());
+
+        return container;
+    }
 }

--- a/DepenMock.NSubstitute/README.md
+++ b/DepenMock.NSubstitute/README.md
@@ -143,6 +143,22 @@ Container
     .Returns(Container.CreateMany<Desk>());
 ```
 
+**Creating a stub with `SetupMock`**
+
+For stubs that don't need to be verified later, `SetupMock<T>()` applies the configuration inline and returns the `Container`, so several dependencies can be stubbed in a single chain without intermediate variables.
+
+```c#
+Container
+    .SetupMock<IDeskRepository>(s => s
+        .GetAvailableDesks(Arg.Any<DateTime>())
+        .Returns(Container.CreateMany<Desk>()))
+    .SetupMock<IDeskBookingRepository>(s => s
+        .When(x => x.Save(Arg.Any<DeskBooking>()))
+        .Do(_ => throw new InvalidOperationException()));
+```
+
+`SetupMock<T>()` configures the same cached substitute that `ResolveMock<T>()` returns, so the two can be mixed freely.
+
 **Creating a spy**
 
 ```c#

--- a/README.md
+++ b/README.md
@@ -107,19 +107,35 @@ var deskBookingResult = Container
 
 DepenMock's testing framework automatically creates mock dependencies, but you can obtain a reference to a mock dependency to set up methods to return predefined data (stub) or to verify interactions with the dependency (spy).
 
+`ResolveMock<T>()` returns a framework-agnostic `IMock<T>`. Unwrap it with the extension method from your mocking adapter — `AsMoq()`, `AsNSubstitute()`, or `AsFake()` — to reach that framework's own APIs. The examples below use Moq.
+
 **Creating a stub**
 
 ```c#
 Container
     .ResolveMock<IDeskRepository>()
+    .AsMoq()
     .Setup(x => x.GetAvailableDesks(It.IsAny<DateTime>()))
     .Returns(Container.CreateMany<Desk>());
+```
+
+**Creating a stub with `SetupMock`**
+
+For stubs that don't need to be verified later, `SetupMock<T>()` applies the configuration inline and returns the `Container`, so several dependencies can be stubbed in a single chain without intermediate variables.
+
+```c#
+Container
+    .SetupMock<IDeskRepository>(m => m
+        .Setup(x => x.GetAvailableDesks(It.IsAny<DateTime>()))
+        .Returns(Container.CreateMany<Desk>()))
+    .SetupMock<IDeskBookingRepository>(m => m
+        .Setup(x => x.Save(It.IsAny<DeskBooking>())));
 ```
 
 **Creating a spy**
 
 ```c#
-var mockRepo = Container.ResolveMock<IDeskBookingRepository>();
+var mockRepo = Container.ResolveMock<IDeskBookingRepository>().AsMoq();
 
 mockRepo.Verify(x => x.Save(It.IsAny<DeskBooking>()), Times.Once);
 ```

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,42 @@
 
 ---
 
+## v3.2.0
+
+### What's Changed
+
+**`SetupMock<T>()` convenience method added to all mocking adapters**
+
+Stubbing a dependency previously required two operations — resolving the mock and then chaining a setup call — along with an intermediate variable when more than one dependency needed configuring. Each mocking adapter (`DepenMock.Moq`, `DepenMock.NSubstitute`, `DepenMock.FakeItEasy`) now provides a `SetupMock<T>()` extension method on `Container` that applies the configuration inline and returns the `Container`, so setups can be chained.
+
+`SetupMock<T>()` takes the mock type native to its adapter, and configures the same cached mock instance that `ResolveMock<T>()` returns — the two can be mixed freely. Continue to use `ResolveMock<T>()` when you need to hold a reference for verification.
+
+```csharp
+// Moq
+Container
+    .SetupMock<IDeskRepository>(m => m
+        .Setup(x => x.GetAvailableDesks(It.IsAny<DateTime>()))
+        .Returns(Container.CreateMany<Desk>()))
+    .SetupMock<IDeskBookingRepository>(m => m
+        .Setup(x => x.Save(It.IsAny<DeskBooking>())));
+
+// NSubstitute
+Container.SetupMock<IDeskRepository>(s => s
+    .GetAvailableDesks(Arg.Any<DateTime>())
+    .Returns(Container.CreateMany<Desk>()));
+
+// FakeItEasy
+Container.SetupMock<IDeskRepository>(f => A
+    .CallTo(() => f.GetAvailableDesks(A<DateTime>._))
+    .Returns(Container.CreateMany<Desk>()));
+```
+
+This is an additive, non-breaking change; no existing code needs to be updated.
+
+**Note:** because each adapter defines its own `SetupMock<T>()`, a single file that imports two adapter namespaces (for example `using DepenMock.Moq;` together with `using DepenMock.NSubstitute;`) can produce an ambiguous-overload error. Drop the unused `using`, or call the method in static form (`MoqExtensions.SetupMock(Container, ...)`), to disambiguate.
+
+---
+
 ## v3.1.0
 
 ### What's Changed

--- a/Tests.FakeItEasy/ContainerTests.cs
+++ b/Tests.FakeItEasy/ContainerTests.cs
@@ -1,0 +1,64 @@
+using DepenMock.FakeItEasy;
+using FakeItEasy;
+
+namespace Tests.FakeItEasy;
+
+public class ContainerTests
+{
+    private readonly DepenMock.Container _container;
+
+    public ContainerTests()
+    {
+        _container = new DepenMock.Container(new FakeItEasyMockFactory());
+    }
+
+    [Fact]
+    public void SetupMock_ShouldApplyConfigurationToResolvedMock()
+    {
+        // Assemble
+        var expectedValue = _container.Create<string>();
+
+        // Act
+        _container.SetupMock<ITestService>(f => A.CallTo(() => f.GetValue()).Returns(expectedValue));
+
+        // Assert
+        Assert.Equal(expectedValue, _container.ResolveMock<ITestService>().Object.GetValue());
+    }
+
+    [Fact]
+    public void SetupMock_ShouldReturnSameContainerForChaining()
+    {
+        // Act
+        var result = _container.SetupMock<ITestService>(f => A.CallTo(() => f.GetValue()).Returns("value"));
+
+        // Assert
+        Assert.Same(_container, result);
+    }
+
+    [Fact]
+    public void SetupMock_ShouldConfigureThePreviouslyResolvedMock()
+    {
+        // Assemble
+        var expectedValue = _container.Create<string>();
+        var mock = _container.ResolveMock<ITestService>();
+
+        // Act
+        _container.SetupMock<ITestService>(f => A.CallTo(() => f.GetValue()).Returns(expectedValue));
+
+        // Assert
+        Assert.Same(mock, _container.ResolveMock<ITestService>());
+        Assert.Equal(expectedValue, mock.Object.GetValue());
+    }
+
+    [Fact]
+    public void SetupMock_WithNullSetup_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _container.SetupMock<ITestService>(null));
+    }
+
+    public interface ITestService
+    {
+        string GetValue();
+    }
+}

--- a/Tests.FakeItEasy/DeskBookingRequestProcessorTests.cs
+++ b/Tests.FakeItEasy/DeskBookingRequestProcessorTests.cs
@@ -112,9 +112,9 @@ public class DeskBookingRequestProcessorTests : FakeItEasyBaseTestByAbstraction<
 	{
         // Assemble
         var correlationId = Container.Create<string>();
-        var fakeDeskRepo = Container.ResolveMock<IDeskRepository>().AsFake();
-        A.CallTo(() => fakeDeskRepo.GetAvailableDesks(A<DateTime>._))
-            .Returns(new List<Desk>());
+        Container.SetupMock<IDeskRepository>(f => A
+            .CallTo(() => f.GetAvailableDesks(A<DateTime>._))
+            .Returns(new List<Desk>()));
 
 		var sut = ResolveSut();
 

--- a/Tests.NSubstitute/ContainerTests.cs
+++ b/Tests.NSubstitute/ContainerTests.cs
@@ -1,0 +1,64 @@
+using DepenMock.NSubstitute;
+using NSubstitute;
+
+namespace Tests.NSubstitute;
+
+public class ContainerTests
+{
+    private readonly DepenMock.Container _container;
+
+    public ContainerTests()
+    {
+        _container = new DepenMock.Container(new NSubstituteMockFactory());
+    }
+
+    [Fact]
+    public void SetupMock_ShouldApplyConfigurationToResolvedMock()
+    {
+        // Assemble
+        var expectedValue = _container.Create<string>();
+
+        // Act
+        _container.SetupMock<ITestService>(s => s.GetValue().Returns(expectedValue));
+
+        // Assert
+        Assert.Equal(expectedValue, _container.ResolveMock<ITestService>().Object.GetValue());
+    }
+
+    [Fact]
+    public void SetupMock_ShouldReturnSameContainerForChaining()
+    {
+        // Act
+        var result = _container.SetupMock<ITestService>(s => s.GetValue().Returns("value"));
+
+        // Assert
+        Assert.Same(_container, result);
+    }
+
+    [Fact]
+    public void SetupMock_ShouldConfigureThePreviouslyResolvedMock()
+    {
+        // Assemble
+        var expectedValue = _container.Create<string>();
+        var mock = _container.ResolveMock<ITestService>();
+
+        // Act
+        _container.SetupMock<ITestService>(s => s.GetValue().Returns(expectedValue));
+
+        // Assert
+        Assert.Same(mock, _container.ResolveMock<ITestService>());
+        Assert.Equal(expectedValue, mock.Object.GetValue());
+    }
+
+    [Fact]
+    public void SetupMock_WithNullSetup_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _container.SetupMock<ITestService>(null));
+    }
+
+    public interface ITestService
+    {
+        string GetValue();
+    }
+}

--- a/Tests.NSubstitute/DeskBookingRequestProcessorTests.cs
+++ b/Tests.NSubstitute/DeskBookingRequestProcessorTests.cs
@@ -115,9 +115,9 @@ public class DeskBookingRequestProcessorTests : NSubstituteBaseTestByAbstraction
         // Assemble
         var correlationId = Container.Create<string>();
         Container
-			.ResolveMock<IDeskRepository>().AsNSubstitute()
-			.GetAvailableDesks(Arg.Any<DateTime>())
-			.Returns(new List<Desk>());
+			.SetupMock<IDeskRepository>(s => s
+				.GetAvailableDesks(Arg.Any<DateTime>())
+				.Returns(new List<Desk>()));
 
 		var sut = ResolveSut();
 

--- a/Tests.XUnit/ContainerTests.cs
+++ b/Tests.XUnit/ContainerTests.cs
@@ -132,6 +132,51 @@ public class ContainerTests
     }
 
     [Fact]
+    public void SetupMock_ShouldApplyConfigurationToResolvedMock()
+    {
+        // Arrange
+        var expectedValue = _container.Create<string>();
+
+        // Act
+        _container.SetupMock<ITestService>(m => m.Setup(x => x.GetValue()).Returns(expectedValue));
+
+        // Assert
+        Assert.Equal(expectedValue, _container.ResolveMock<ITestService>().Object.GetValue());
+    }
+
+    [Fact]
+    public void SetupMock_ShouldReturnSameContainerForChaining()
+    {
+        // Act
+        var result = _container.SetupMock<ITestService>(m => m.Setup(x => x.GetValue()).Returns("value"));
+
+        // Assert
+        Assert.Same(_container, result);
+    }
+
+    [Fact]
+    public void SetupMock_ShouldConfigureThePreviouslyResolvedMock()
+    {
+        // Arrange
+        var expectedValue = _container.Create<string>();
+        var mock = _container.ResolveMock<ITestService>();
+
+        // Act
+        _container.SetupMock<ITestService>(m => m.Setup(x => x.GetValue()).Returns(expectedValue));
+
+        // Assert
+        Assert.Same(mock, _container.ResolveMock<ITestService>());
+        Assert.Equal(expectedValue, mock.Object.GetValue());
+    }
+
+    [Fact]
+    public void SetupMock_WithNullSetup_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _container.SetupMock<ITestService>(null));
+    }
+
+    [Fact]
     public void Register_WithInstance_ShouldReturnRegisteredInstance()
     {
         // Arrange
@@ -201,6 +246,8 @@ public class ContainerTests
     public interface ITestService
     {
         void DoSomething();
+
+        string GetValue();
     }
 
     public class TestService : ITestService
@@ -209,5 +256,7 @@ public class ContainerTests
         {
             // Implementation
         }
+
+        public string GetValue() => string.Empty;
     }
 }

--- a/Tests.XUnit/DeskBookingRequestProcessorTests.cs
+++ b/Tests.XUnit/DeskBookingRequestProcessorTests.cs
@@ -118,9 +118,9 @@ public class DeskBookingRequestProcessorTests : BaseTestByAbstraction<DeskBookin
         // Assemble
         var correlationId = Container.Create<string>();
         Container
-			.ResolveMock<IDeskRepository>().AsMoq()
-			.Setup(x => x.GetAvailableDesks(It.IsAny<DateTime>()))
-			.Returns(new List<Desk>());
+			.SetupMock<IDeskRepository>(m => m
+				.Setup(x => x.GetAvailableDesks(It.IsAny<DateTime>()))
+				.Returns(new List<Desk>()));
 
 		var sut = ResolveSut();
 


### PR DESCRIPTION
## Description

Closes #35.

Stubbing a dependency previously required two operations — resolving the mock and then chaining a setup call — plus an intermediate variable when more than one dependency needed configuring.

Each mocking adapter now provides a `SetupMock<T>()` extension method on `Container` that applies the configuration inline and returns the `Container`, so setups can be chained. It takes the mock type native to its adapter and delegates to the existing `ResolveMock<T>()`, so it configures the same cached mock instance — the two can be mixed freely. Continue to use `ResolveMock<T>()` when you need to hold a reference for verification.

```csharp
Container
    .SetupMock<IDeskRepository>(m => m
        .Setup(x => x.GetAvailableDesks(It.IsAny<DateTime>()))
        .Returns(Container.CreateMany<Desk>()))
    .SetupMock<IDeskBookingRepository>(m => m
        .Setup(x => x.Save(It.IsAny<DeskBooking>())));
```

### A note on the issue's API shape

Issue #35 was filed before the mocking abstraction shipped, so its example is written against raw Moq (`Action<Mock<T>>`). The issue explicitly gated itself on that work:

> if a mocking framework abstraction replacement occurs in the same major release, `SetupMock<T>()` should accept the wrapper type rather than `Mock<T>` directly to avoid subsequent breaking changes.

That precondition is satisfied as of v3.0.0. A core-level `SetupMock<T>(Action<IMock<T>>)` was considered and rejected: `IMock<T>` exposes only `Object`, so every lambda would still have to unwrap via `AsMoq()`/`AsNSubstitute()`/`AsFake()`, and a `Container` instance method would shadow the adapter extensions during overload resolution. Per-adapter extensions give the ergonomics the issue asked for and leave the core package untouched.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Added `SetupMock<T>()` extension methods on `Container`: `Action<Mock<T>>` in `DepenMock.Moq`, `Action<T>` in `DepenMock.NSubstitute` and `DepenMock.FakeItEasy`
- Added 12 tests (4 per adapter) covering configuration reaching the SUT-visible object, `Container` returned for chaining, a previously-resolved mock being the one configured, and `ArgumentNullException` on a null setup delegate
- Converted one stub-only test in each of the three `DeskBookingRequestProcessorTests` to use `SetupMock`, exercising the API through the real `BaseTestByAbstraction` path
- Documented `SetupMock` in all three adapter READMEs, the root README, and a new `v3.2.0` entry in `RELEASES.md`
- Fixed stale docs found along the way: the root README stub/spy examples were missing the `AsMoq()` unwrap required since v3.0.0, and `CLAUDE.md` was missing the `DepenMock.FakeItEasy` adapter row and still referred to `Container.GetMock<T>()`

## Known edge case

Because each adapter defines its own `SetupMock<T>()`, a single file importing two adapter namespaces (e.g. `using DepenMock.Moq;` together with `using DepenMock.NSubstitute;`) can produce an ambiguous-overload error. This is an unusual configuration — a project normally uses one mocking framework — and the workaround is to drop the unused `using` or call the method in static form. Documented in `RELEASES.md` rather than solved by renaming.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

`dotnet build --configuration Release` — 0 errors. `dotnet test --configuration Release` — all 12 test assemblies pass, 0 failures, across `net8.0` and `net10.0`. No existing test needed modification.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
