### PR TITLE
docs: Refresh stale facts in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ dotnet pack --configuration Release /p:Version=$VERSION
 
 ## Architecture
 
-DepenMock is a .NET 8 test helper library that combines AutoFixture with a pluggable mocking framework to auto-mock dependencies in unit tests. It is split into separate NuGet packages.
+DepenMock is a test helper library that combines AutoFixture with a pluggable mocking framework to auto-mock dependencies in unit tests. Every project multi-targets `net8.0` and `net10.0`. It is split into separate NuGet packages.
 
 ### Core (`DepenMock/`)
 
@@ -31,7 +31,7 @@ DepenMock is a .NET 8 test helper library that combines AutoFixture with a plugg
 - **`IMock<T>` / `IMockFactory`** — abstractions that decouple the core from any specific mocking library. Each mocking-framework adapter implements `IMockFactory` to produce `IMock<T>` wrappers.
 - **`BaseTest` / `BaseTestByAbstraction<,>` / `BaseTestByType<>`** — base test classes (provided per test-framework adapter) with a `Container` property and a virtual `AddContainerCustomizations()` hook.
 - **`ListLogger<T>`** — in-memory `ILogger<T>` implementation for asserting log output in tests.
-- **`LogOutputAttribute`** — attribute (xUnit v3 only) that pipes log output to test output.
+- **`LogOutputAttribute`** / **`LogOutputHelper`** — attribute (with a `LogOutputTiming` of `Always` / `OnFailure` / `OnSuccess`) that pipes log output to the test runner's output, plus the shared helper that decides whether to emit and formats the messages. The `DepenMock.NUnit`, `DepenMock.MSTest`, and `DepenMock.XUnit` base classes honor this core attribute. `DepenMock.XUnit.V3` ships its **own** `LogOutputAttribute` that must be used instead — only xUnit v3 exposes test outcome (via `IBeforeAfterTestAttribute`), which the timing modes need.
 
 ### Mocking-framework adapters
 
@@ -51,8 +51,8 @@ Each adapter also defines a `SetupMock<T>()` extension method on `Container` tha
 
 ### Sample / test projects
 
-`DeskBooker.Core` is a sample domain model used only by the five `Tests.*` projects to demonstrate real usage of each adapter combination. It is not a deployable package.
+`DeskBooker.Core` is a sample domain model used only by the six `Tests.*` projects to demonstrate real usage of each adapter combination. It is not a deployable package.
 
 ## Package publishing
 
-Releases are triggered by pushing a `v*` git tag. All seven NuGet packages are versioned identically. See `CONTRIBUTING.md` for the exact tagging steps and `RELEASES.md` for breaking-change history.
+Releases are triggered by pushing a `v*` git tag. All eight NuGet packages are versioned identically. See `CONTRIBUTING.md` for the exact tagging steps and `RELEASES.md` for breaking-change history.


### PR DESCRIPTION
## Description

Follow-up to #46. While confirming that `CLAUDE.md` covered all three mocking adapters, I found four claims that had drifted from the codebase. This corrects them.

The `LogOutputAttribute` one is the notable fix — it was stated backwards, so anyone (human or agent) reading `CLAUDE.md` would reach for the wrong attribute.

## Type of Change

- [x] Documentation update

## Changes Made

- **`.NET 8` → multi-targeted** — every project has targeted `net8.0;net10.0` since #45
- **`LogOutputAttribute` was described as "xUnit v3 only"** — it's the reverse. The core attribute is honored by the `DepenMock.NUnit`, `DepenMock.MSTest`, and `DepenMock.XUnit` base classes through `LogOutputHelper.ShouldOutputLogs`. xUnit v3 is the one framework that needs its *own* `LogOutputAttribute` (`DepenMock.XUnit.V3/Attributes/`), because only v3 exposes test outcome via `IBeforeAfterTestAttribute`, which the timing modes depend on. The entry now also names `LogOutputHelper` and the `LogOutputTiming` modes (`Always` / `OnFailure` / `OnSuccess`)
- **"five `Tests.*` projects" → six** — `Tests.FakeItEasy` was added in v3.1.0
- **"seven NuGet packages" → eight** — there are eight `PackageId`s across the repo

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

Documentation only — no code changes, so no build or test behavior is affected. The corrected claims were each verified against the source: `TargetFrameworks` in the `.csproj` files, the `LogOutputHelper` call sites in the four test-framework adapters, `ls -d Tests.*/`, and the `PackageId` declarations.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
